### PR TITLE
Add 'upgrade' feature and PHPUnit tests

### DIFF
--- a/classes/local/util/manager.php
+++ b/classes/local/util/manager.php
@@ -139,6 +139,13 @@ class manager {
         if ($this->should_have('settings')) {
             $this->prepare_file_skeleton('settings.php', 'php_internal_file', 'settings');
         }
+
+        if ($this->should_have('upgrade')) {
+            $this->prepare_file_skeleton('db/upgrade.php', 'php_internal_file', 'db_upgrade');
+            if ($this->should_have('upgradelib')) {
+                $this->prepare_file_skeleton('db/upgradelib.php', 'php_internal_file', 'db_upgradelib');
+            }
+        }
     }
 
     /**
@@ -192,6 +199,10 @@ class manager {
 
         if ($feature === 'capabilities') {
             return !empty($this->recipe['capabilities']);
+        }
+
+        if ($feature === 'upgradelib') {
+            return !empty($this->recipe['upgrade']['upgradelib']);
         }
 
         return false;

--- a/skel/file/db_upgrade.mustache
+++ b/skel/file/db_upgrade.mustache
@@ -1,0 +1,36 @@
+{{!
+    settings.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Plugin upgrade steps are defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+{{# upgrade.upgradelib}}
+
+require_once(__DIR__.'/upgradelib.php');
+{{/ upgrade.upgradelib}}
+
+/**
+ * Execute {{component}} upgrade from the given old version.
+ *
+ * @param int $oldversion
+ * @return bool
+ */
+function xmldb_{{component}}_upgrade($oldversion) {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    // For further information please read the Upgrade API documentation:
+    // https://docs.moodle.org/dev/Upgrade_API
+    //
+    // You will also have to create the db/install.xml file by using the XMLDB Editor.
+    // Documentation for the XMLDB Editor can be found at:
+    // https://docs.moodle.org/dev/XMLDB_editor
+
+    return true;
+}

--- a/skel/file/db_upgradelib.mustache
+++ b/skel/file/db_upgradelib.mustache
@@ -1,0 +1,24 @@
+{{!
+    settings.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Plugin upgrade helper functions are defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+
+/**
+ * Helper function used by the upgrade.php file.
+ */
+function {{component}}_helper_function() {
+    global $DB;
+
+    // Please note that you should always be performing any task using raw (low
+    // level) database access exclusively, avoiding any use of the Moodle APIs.
+    //
+    // For more information please read the available Moodle documentation:
+    // https://docs.moodle.org/dev/Upgrade_API
+}

--- a/tests/upgrade_test.php
+++ b/tests/upgrade_test.php
@@ -1,0 +1,102 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing tests for the 'upgrade' feature.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+use tool_pluginskel\local\util\manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/setuplib.php');
+require_once($CFG->dirroot . '/' . $CFG->admin . '/tool/pluginskel/vendor/autoload.php');
+
+/**
+ * Upgrade test class.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei alexandru.elisei@gmail.com
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_pluginskel_upgrade_testcase extends advanced_testcase {
+
+    /** @var string[] The test recipe. */
+    protected static $recipe = array(
+        'component' => 'upgradetest',
+        'name'      => 'Upgrade test',
+        'copyright' => '2016 Alexandru Elisei <alexandru.elisei@gmail.com>',
+        'features'  => array(
+            'all' => false,
+            'upgrade' => true
+        )
+    );
+
+    /**
+     * Test creating the db/upgrade.php file.
+     */
+    public function test_upgrade() {
+        $logger = new Logger('upgradetest');
+        $logger->pushHandler(new NullHandler);
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('db/upgrade.php', $files);
+        $this->assertArrayNotHasKey('db/upgradelib.php', $files);
+        $upgradefile = $files['db/upgrade.php'];
+
+        $description = 'Plugin upgrade steps are defined here.';
+        $this->assertContains($description, $upgradefile);
+        $this->assertNotContains("require_once(__DIR__.'/upgradelib.php')", $upgradefile);
+        $this->assertContains('function xmldb_'.$recipe['component'].'_upgrade($oldversion)', $upgradefile);
+    }
+
+    /**
+     * Test creating the db/upgradelib.php file.
+     */
+    public function test_upgrade_with_upgradelib() {
+        $logger = new Logger('upgradetest');
+        $logger->pushHandler(new NullHandler);
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $recipe['upgrade'] = array('upgradelib' => true);
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('db/upgradelib.php', $files);
+        $upgradefile = $files['db/upgrade.php'];
+        $upgradelibfile = $files['db/upgradelib.php'];
+
+        $this->assertContains("require_once(__DIR__.'/upgradelib.php')", $upgradefile);
+
+        $description = 'Plugin upgrade helper functions are defined here.';
+        $this->assertContains($description, $upgradelibfile);
+        $this->assertContains($recipe['component'].'_helper_function()', $upgradelibfile);
+    }
+}


### PR DESCRIPTION
Given the recipe:
```
component: readmetest
name: Readme test
release: "0.1.0"
requires: "2.9"
copyright: 2016 Alexandru Elisei <alexandru.elisei@gmail.com>
features:
  upgrade: true
```

The db/upgrade.php file will be created.