### PR TITLE
Backup_moodle2 feature

### DIFF
--- a/classes/local/skel/backup_activity_task_file.php
+++ b/classes/local/skel/backup_activity_task_file.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provides tool_pluginskel\local\skel\backup_activity_task_file class.
+ *
+ * @package     tool_pluginskel
+ * @subpackage  skel
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_pluginskel\local\skel;
+
+use tool_pluginskel\local\util\exception;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class representing the plugin's backup_activity_task.class.php file.
+ *
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_activity_task_file extends php_internal_file {
+
+    /**
+     * Set the data to be eventually rendered.
+     *
+     * @param array $data
+     */
+    public function set_data(array $data) {
+
+        parent::set_data($data);
+
+        $this->data['component_name_all_caps'] = \core_text::strtoupper($this->data['component_name']);
+    }
+}

--- a/classes/local/util/manager.php
+++ b/classes/local/util/manager.php
@@ -154,6 +154,41 @@ class manager {
                 $this->prepare_file_skeleton('db/upgradelib.php', 'php_internal_file', 'db_upgradelib');
             }
         }
+
+        if ($this->should_have('backup_moodle2')) {
+            $this->prepare_backup_moodle2();
+        }
+    }
+
+    /**
+     * Prepares the skeleton files for the 'backup_moodle2' feature.
+     */
+    public function prepare_backup_moodle2() {
+
+        // TODO: Lib.php will advertise the fact that the plugin supports backup.
+        /*
+        if (!isset($this->files['lib.php'])) {
+            $this->prepare_file_skeleton('lib.php', 'lib_php_file', 'lib');
+        }
+         */
+
+        $componentname = $this->recipe['component_name'];
+        $this->prepare_file_skeleton('backup/moodle2/backup_'.$componentname.'_activity_task.class.php', 'backup_activity_task_file',
+                                     'backup/moodle2/backup_activity_task_class');
+
+        $this->prepare_file_skeleton('backup/moodle2/backup_'.$componentname.'_stepslib.php', 'php_internal_file',
+                                     'backup/moodle2/backup_stepslib');
+
+        if ($this->should_have('settingslib')) {
+            $this->prepare_file_skeleton('backup/moodle2/backup_'.$componentname.'_settingslib.php', 'php_internal_file',
+                'backup/moodle2/backup_settingslib');
+        }
+
+        $this->prepare_file_skeleton('backup/moodle2/restore_'.$componentname.'_activity_task.class.php', 'php_internal_file',
+                                     'backup/moodle2/restore_activity_task_class');
+
+        $this->prepare_file_skeleton('backup/moodle2/restore_'.$componentname.'_stepslib.php', 'php_internal_file',
+                                     'backup/moodle2/restore_stepslib');
     }
 
     /**
@@ -211,6 +246,18 @@ class manager {
 
         if ($feature === 'upgradelib') {
             return !empty($this->recipe['upgrade']['upgradelib']);
+        }
+
+        if ($feature === 'backup_moodle2') {
+            return !empty($this->recipe['backup_moodle2']);
+        }
+
+        if ($feature === 'settingslib') {
+
+            $shouldhavebackup = $this->should_have('backup_moodle2');
+            $notempty = !empty($this->recipe['backup_moodle2']['settingslib']);
+
+            return $shouldhavebackup && $notempty && ($this->recipe['backup_moodle2']['settingslib'] === true);
         }
 
         return false;

--- a/skel/file/backup/moodle2/backup_activity_task_class.mustache
+++ b/skel/file/backup/moodle2/backup_activity_task_class.mustache
@@ -1,0 +1,64 @@
+{{!
+    backup/moodle2/backup_activity_task.class.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}The task that provides all the steps to perform a complete backup is defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{$ extratags }}
+ * @subpackage  backup-moodle2
+{{/extratags}}
+{{/ common/boilerplate_php }}
+
+require_once($CFG->dirroot.'/{{ component_root }}/{{ component_name }}/backup/moodle2/backup_{{ component_name }}_stepslib.php');
+{{# backup_moodle2.settingslib }}
+require_once($CFG->dirroot.'/{{ component_root }}/{{ component_name }}/backup/moodle2/backup_{{ component_name }}_settingslib.php');
+{{/ backup_moodle2.settingslib }}
+
+// For more information about the backup and restore process, please visit:
+// https://docs.moodle.org/dev/Backup_2.0_for_developers
+// https://docs.moodle.org/dev/Restore_2.0_for_developers
+
+/**
+ * The class provides all the settings and steps to perform one complete backup
+ * of {{ component }}.
+ */
+class backup_{{ component_name }}_activity_task extends backup_activity_task {
+
+    /**
+     * Defines particular settings for the plugin.
+     */
+    protected function define_my_settings() {
+        return;
+    }
+
+    /**
+     * Defines particular steps for the backup process.
+     */
+    protected function define_my_steps() {
+        $this->add_step(new backup_{{ component_name }}_activity_structure_step('{{ component_name }}_structure', '{{ component_name }}.xml');
+    }
+
+    /**
+     * Codes the transformations to perform in the activity in order to get
+     * transportable (encoded) links.
+     */
+    static public function encode_content_links($content) {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot,"/");
+
+        // Link to the list of choices
+        $search="/(".$base."\/{{ component_root }}\/{{ component_name }}\/index.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@{{ component_name_all_caps }}INDEX*$2@$', $content);
+
+        // Link to choice view by moduleid
+        $search="/(".$base."\/{{ component_root }}\/{{ component_name }}\/view.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@{{ component_name_all_caps }}VIEWBYID*$2@$', $content);
+
+        return $content;
+    }
+}

--- a/skel/file/backup/moodle2/backup_activity_task_class.mustache
+++ b/skel/file/backup/moodle2/backup_activity_task_class.mustache
@@ -9,7 +9,7 @@
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{$ extratags }}
- * @subpackage  backup-moodle2
+ * @category    backup
 {{/extratags}}
 {{/ common/boilerplate_php }}
 

--- a/skel/file/backup/moodle2/backup_settingslib.mustache
+++ b/skel/file/backup/moodle2/backup_settingslib.mustache
@@ -1,0 +1,18 @@
+{{!
+    backup/moodle2/backup_settings.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Plugin custom settings are defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{$ extratags }}
+ * @subpackage  backup-moodle2
+{{/extratags}}
+{{/ common/boilerplate_php }}
+
+// For further information about the backup and restore process, please visit:
+// https://docs.moodle.org/dev/Backup_2.0_for_developers
+// https://docs.moodle.org/dev/Restore_2.0_for_developers

--- a/skel/file/backup/moodle2/backup_settingslib.mustache
+++ b/skel/file/backup/moodle2/backup_settingslib.mustache
@@ -9,7 +9,7 @@
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{$ extratags }}
- * @subpackage  backup-moodle2
+ * @category    backup
 {{/extratags}}
 {{/ common/boilerplate_php }}
 

--- a/skel/file/backup/moodle2/backup_stepslib.mustache
+++ b/skel/file/backup/moodle2/backup_stepslib.mustache
@@ -1,0 +1,53 @@
+{{!
+    backup/moodle2/backup_stepslib.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Backup steps for {{ component }} are defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{$ extratags }}
+ * @subpackage  backup-moodle2
+{{/extratags}}
+{{/ common/boilerplate_php }}
+
+// For more information about the backup and restore process, please visit:
+// https://docs.moodle.org/dev/Backup_2.0_for_developers
+// https://docs.moodle.org/dev/Restore_2.0_for_developers
+
+/**
+ * Define the complete structure for backup, with file and id annotations.
+ */
+class backup_{{ component_name }}_activity_structure_step extends backup_activity_structure_step {
+
+    /**
+     * Defines the structure of the resulting xml file.
+     */
+    protected function define_structure() {
+        $userinfo = $this->get_setting_value('userinfo');
+
+        // Replace with the attributes and final elements that the element will handle.
+        $attributes = null;
+        $final_elements = null;
+        $root = new backup_nested_element('{{ component }}', $attributes, $final_elements);
+        {{# backup_moodle2.backup_elements}}
+
+        // Replace with the attributes and final elements that the element will handle.
+        $attributes = null;
+        $final_elements = null;
+        ${{ . }} = new backup_nested_element('{{ . }}', $attributes, $final_elements);
+        {{/ backup_moodle2.backup_elements}}
+
+        // Build the tree with these elements with $root as the root of the backup tree.
+
+        // Define the source tables for the elements.
+
+        // Define id annotations.
+
+        // Define file annotations.
+
+        return $this->prepare_activity_structure($root);
+    }
+}

--- a/skel/file/backup/moodle2/backup_stepslib.mustache
+++ b/skel/file/backup/moodle2/backup_stepslib.mustache
@@ -9,7 +9,7 @@
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{$ extratags }}
- * @subpackage  backup-moodle2
+ * @category    backup
 {{/extratags}}
 {{/ common/boilerplate_php }}
 

--- a/skel/file/backup/moodle2/restore_activity_task_class.mustache
+++ b/skel/file/backup/moodle2/restore_activity_task_class.mustache
@@ -1,0 +1,76 @@
+{{!
+    backup/moodle2/restore_stepslib.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}The task that provides a complete restore of {{ component }} is defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{$ extratags }}
+ * @subpackage  backup-moodle2
+{{/extratags}}
+{{/ common/boilerplate_php }}
+
+// For further information about the backup and restore process, please visit:
+// https://docs.moodle.org/dev/Backup_2.0_for_developers
+// https://docs.moodle.org/dev/Restore_2.0_for_developers
+
+require_once($CFG->dirroot.'/{{ component_root }}/{{ component_name }}/backup/moodle2/restore_{{ component_name }}_stepslib.php');
+
+/**
+ * Restore task for {{ component }}.
+ */
+class restore_{{ component_name }}_activity_task extends restore_activity_task {
+
+    /**
+     * Defines particular settings that this activity can have.
+     */
+    protected function define_my_settings() {
+        return;
+    }
+
+    /**
+     * Defines particular steps that this activity can have.
+     */
+    protected function define_my_steps() {
+        $this->add_step(new restore_{{ component_name }}_activity_structure_step('{{ component_name }}_structure', '{{ component_name }}.xml');
+    }
+
+    /**
+     * Defines the contents in the activity that must be processed by the link decoder.
+     */
+    static public function define_decode_contents() {
+        $contents = array();
+
+        // Define the contents.
+
+        return $contents;
+    }
+
+    /**
+     * Defines the decoding rules for links belonging to the activity to be
+     * executed by the link decoder.
+     */
+    static public function define_decode_rules() {
+        $rules = array();
+
+        // Define the rules.
+
+        return $rules.
+    }
+
+    /**
+     * Defines the restore log rules that will be applied by the
+     * {@link restore_logs_processor} when restoring {{ component }} logs. It
+     * must return one array of {@link restore_log_rule} objects.
+     */
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        // Define the rules.
+
+        return $rules;
+    }
+}

--- a/skel/file/backup/moodle2/restore_activity_task_class.mustache
+++ b/skel/file/backup/moodle2/restore_activity_task_class.mustache
@@ -9,7 +9,7 @@
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{$ extratags }}
- * @subpackage  backup-moodle2
+ * @category    restore
 {{/extratags}}
 {{/ common/boilerplate_php }}
 

--- a/skel/file/backup/moodle2/restore_stepslib.mustache
+++ b/skel/file/backup/moodle2/restore_stepslib.mustache
@@ -1,0 +1,57 @@
+{{!
+    backup/moodle2/restore_stepslib.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}All the steps to restore {{ component }} are defined here.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{$ extratags }}
+ * @subpackage  backup-moodle2
+{{/extratags}}
+{{/ common/boilerplate_php }}
+
+// For further information about the backup and restore process, please visit:
+// https://docs.moodle.org/dev/Backup_2.0_for_developers
+// https://docs.moodle.org/dev/Restore_2.0_for_developers
+
+/**
+ * Defines the structure step to restore one {{ component }} activity.
+ */
+class restore_{{ component_name }}_activity_structure_step extends restore_activity_structure_step {
+
+    /**
+     * Defines the structure to be restored.
+     */
+    protected function define_structure() {
+        $paths = array();
+        $userinfo = $this->get_setting_value('userinfo');
+
+        {{# backup_moodle2.restore_elements }}
+        $paths[] = new restore_path_element('{{ name }}', '{{ path }}');
+        {{/ backup_moodle2.restore_elements}}
+
+        return $this->prepare_activity_structure($paths);
+    }
+    {{# backup_moodle2.restore_elements}}
+
+    /**
+     * Processes the {{ name }} restore data.
+     */
+    protected function process_{{ name }}($data) {
+        global $DB;
+
+        return $data;
+    }
+    {{/ backup_moodle2.restore_elements}}
+
+    /**
+     * Defines post-execution actions.
+     */
+    protected function after_execute() {
+
+        return;
+    }
+}

--- a/skel/file/backup/moodle2/restore_stepslib.mustache
+++ b/skel/file/backup/moodle2/restore_stepslib.mustache
@@ -9,7 +9,7 @@
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{$ extratags }}
- * @subpackage  backup-moodle2
+ * @category    restore
 {{/extratags}}
 {{/ common/boilerplate_php }}
 

--- a/tests/backup_moodle2_test.php
+++ b/tests/backup_moodle2_test.php
@@ -1,0 +1,270 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing tests for the 'backup_moodle2' feature.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+use tool_pluginskel\local\util\manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/setuplib.php');
+require_once($CFG->dirroot . '/' . $CFG->admin . '/tool/pluginskel/vendor/autoload.php');
+
+/**
+ * Backup_moodle2 test class.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei alexandru.elisei@gmail.com
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_pluginskel_backup_moodle2_testcase extends advanced_testcase {
+
+    /** @var string[] The test recipe. */
+    protected static $recipe = array(
+        'component' => 'backupmoodle2test',
+        'name'      => 'Backup_moodle2 test',
+        'copyright' => '2016 Alexandru Elisei <alexandru.elisei@gmail.com>',
+        'features'  => array(
+            'all' => false
+        ),
+        'backup_moodle2' => array(
+            'backup_elements' => array('node'),
+            'restore_elements' => array(
+                array('name' => 'node', 'path' => '/path/to/file')
+            )
+        )
+    );
+
+    /** @var string The plugin files path relative the Moodle root. */
+    static protected $relpath;
+
+    /** @var string The plugin name, without the frankenstyle prefix. */
+    static protected $pluginname;
+
+    /**
+     * Sets the $relpath and the $pluginname.
+     */
+    public static function setUpBeforeClass() {
+        global $CFG;
+
+        list($type, $pluginname) = \core_component::normalize_component(self::$recipe['component']);
+
+        $plugintypes = \core_component::get_plugin_types();
+        $root = substr($plugintypes[$type], strlen($CFG->dirroot));
+
+        self::$pluginname = $pluginname;
+        self::$relpath = $root.'/'.$pluginname;
+    }
+
+    /**
+     * Tests creating the backup/moodle2/backup_activity_task.class.php file.
+     */
+    public function test_backup_activity_task_class() {
+        $logger = new Logger('backupmoodle2test');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $pluginname = self::$pluginname;
+
+        $files = $manager->get_files_content();
+
+        $filename = 'backup/moodle2/backup_'.$pluginname.'_activity_task.class.php';
+        $this->assertArrayHasKey($filename, $files);
+        $backupfile = $files[$filename];
+
+        // Verify the boilerplate.
+        $description = 'The task that provides all the steps to perform a complete backup is defined here.';
+        $this->assertContains($description, $backupfile);
+
+        $this->assertRegExp('/\* @subpackage\s+backup-moodle2/', $backupfile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
+        $this->assertContains($moodleinternal, $backupfile);
+
+        $settingslibpath = self::$relpath.'/backup/moodle2/backup_'.$pluginname.'_settingslib.php';
+        $this->assertNotContains('require_once($CFG->dirroot.'.'\'/'.$settingslibpath.'\')', $backupfile);
+
+        $stepslibpath = self::$relpath.'/backup/moodle2/backup_'.$pluginname.'_stepslib.php';
+        $this->assertContains('require_once($CFG->dirroot.'.'\'/'.$stepslibpath.'\')', $backupfile);
+
+        $classdefinition = 'class backup_'.$pluginname.'_activity_task extends backup_activity_task';
+        $this->assertContains($classdefinition, $backupfile);
+
+        $stepdefinition = "\$this->add_step(new backup_".$pluginname."_activity_structure_step('".$pluginname."_structure', '".$pluginname.".xml')";
+        $this->assertContains($stepdefinition, $backupfile);
+    }
+
+    /**
+     * Tests creating the backup/moodle2/backup_settingslib.php file.
+     */
+    public function test_backup_settingslib() {
+        $logger = new Logger('backupmoodle2test');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $recipe['backup_moodle2']['settingslib'] = true;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $pluginname = self::$pluginname;
+
+        $files = $manager->get_files_content();
+        $filename = 'backup/moodle2/backup_'.$pluginname.'_settingslib.php';
+        $this->assertArrayHasKey($filename, $files);
+        $settingslibfile = $files[$filename];
+
+        // Verify the boilerplate.
+        $description = 'Plugin custom settings are defined here.';
+        $this->assertContains($description, $settingslibfile);
+        $this->assertRegExp('/\* @subpackage\s+backup-moodle2/', $settingslibfile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
+        $this->assertContains($moodleinternal, $settingslibfile);
+
+        $filename = 'backup/moodle2/backup_'.$pluginname.'_activity_task.class.php';
+        $activitytaskfile = $files[$filename];
+
+        $settingslibpath = self::$relpath.'/backup/moodle2/backup_'.$pluginname.'_settingslib.php';
+        $this->assertContains('require_once($CFG->dirroot.'.'\'/'.$settingslibpath.'\')', $activitytaskfile);
+    }
+
+    /**
+     * Tests creating the backup/moodle2/backup_stepslib.php file.
+     */
+    public function test_backup_stepslib() {
+        $logger = new Logger('backupmoodle2test');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $pluginname = self::$pluginname;
+
+        $files = $manager->get_files_content();
+        $filename = 'backup/moodle2/backup_'.$pluginname.'_stepslib.php';
+        $this->assertArrayHasKey($filename, $files);
+        $stepslibfile = $files[$filename];
+
+        // Verify the boilerplate.
+        $description = 'Backup steps for '.$recipe['component'].' are defined here.';
+        $this->assertContains($description, $stepslibfile);
+
+        $this->assertRegExp('/\* @subpackage\s+backup-moodle2/', $stepslibfile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
+        $this->assertContains($moodleinternal, $stepslibfile);
+
+        $classdefinition = 'class backup_'.$pluginname.'_activity_structure_step extends backup_activity_structure_step';
+        $this->assertContains($classdefinition, $stepslibfile);
+
+        $element = $recipe['backup_moodle2']['backup_elements'][0];
+        $nestedelement = '$'.$element.' = new backup_nested_element(\''.$element.'\', $attributes, $final_elements)';
+        $this->assertContains($nestedelement, $stepslibfile);
+    }
+
+    /**
+     * Tests creating the backup/moodle2/restore_activity_task.class.php file.
+     */
+    public function test_restore_activity_task() {
+        $logger = new Logger('backupmoodle2test');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $pluginname = self::$pluginname;
+
+        $files = $manager->get_files_content();
+        $filename = 'backup/moodle2/restore_'.$pluginname.'_activity_task.class.php';
+        $this->assertArrayHasKey($filename, $files);
+        $restorefile = $files[$filename];
+
+        // Verify the boilerplate.
+        $description = 'The task that provides a complete restore of '.$recipe['component'].' is defined here.';
+        $this->assertContains($description, $restorefile);
+
+        $this->assertRegExp('/\* @subpackage\s+backup-moodle2/', $restorefile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
+        $this->assertContains($moodleinternal, $restorefile);
+
+        $stepslibpath = self::$relpath.'/backup/moodle2/restore_'.$pluginname.'_stepslib.php';
+        $this->assertContains('require_once($CFG->dirroot.'.'\'/'.$stepslibpath.'\')', $restorefile);
+
+        $classdefinition = 'class restore_'.$pluginname.'_activity_task extends restore_activity_task';
+        $this->assertContains($classdefinition, $restorefile);
+
+        $stepdefinition = "\$this->add_step(new restore_".$pluginname."_activity_structure_step('".$pluginname."_structure', '".$pluginname.".xml')";
+        $this->assertContains($stepdefinition, $restorefile);
+    }
+
+    /**
+     * Tests creating the backup/moodle2/restore_stepslib.php file.
+     */
+    public function test_restore_stepslib() {
+        $logger = new Logger('backupmoodle2test');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $pluginname = self::$pluginname;
+
+        $files = $manager->get_files_content();
+        $filename = 'backup/moodle2/restore_'.$pluginname.'_stepslib.php';
+        $this->assertArrayHasKey($filename, $files);
+        $stepslibfile = $files[$filename];
+
+        // Verify the boilerplate.
+        $description = 'All the steps to restore '.$recipe['component'].' are defined here.';
+        $this->assertContains($description, $stepslibfile);
+
+        $this->assertRegExp('/\* @subpackage\s+backup-moodle2/', $stepslibfile);
+
+        //TODO: restore_stepslib.php is not moodle internal and does not include the config file.
+
+        $classdefinition = 'class restore_'.$pluginname.'_activity_structure_step extends restore_activity_structure_step';
+        $this->assertContains($classdefinition, $stepslibfile);
+
+        $element = $recipe['backup_moodle2']['restore_elements'][0]['name'];
+        $path = $recipe['backup_moodle2']['restore_elements'][0]['path'];
+        $elementpath = "\$paths[] = new restore_path_element('".$element."', '".$path."')";
+        $this->assertContains($elementpath, $stepslibfile);
+
+        $processfunction = 'protected function process_'.$element.'($data)';
+        $this->assertContains($processfunction, $stepslibfile);
+    }
+}


### PR DESCRIPTION
Given the recipe:
```
...
backup_moodle2:
    settingslib: true
    backup_elements:
        - root
    restore_elements:
        - name: root
          path: /path/to/file
```
The backup/moodle2/backup_<pluginname>_settingslib.php, backup/moodle2/backup_<pluginname>_activity_task.class.php, backup/moodle2/backup_<pluginname>_stepslib.php, backup/moodle2/restore_activity_task.class.php, backup/moodle2/restore_stepslib.php files will be created.