### PR TITLE
Use the correct namespace

### DIFF
--- a/skel/file/classes_event_event.mustache
+++ b/skel/file/classes_event_event.mustache
@@ -9,7 +9,7 @@
 {{$ description }}Plugin event classes are defined here.{{/ description }}
 {{$ package }}{{ component }}{{/ package }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{$ namespace }}namespace {{ component }};{{/ namespace }}
+{{$ namespace }}namespace {{ component_type }}_{{ component_name }}\event;{{/ namespace }}
 {{/ common/boilerplate_php }}
 
 /**

--- a/tests/events_test.php
+++ b/tests/events_test.php
@@ -79,7 +79,8 @@ class tool_pluginskel_events_testcase extends advanced_testcase {
         $description = 'Plugin event classes are defined here.';
         $this->assertContains($description, $eventfile);
 
-        $this->assertContains('namespace '.$recipe['component'], $eventfile);
+        list($type, $pluginname) = \core_component::normalize_component($recipe['component']);
+        $this->assertContains('namespace '.$type.'_'.$pluginname.'\event', $eventfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die()";
         $this->assertContains($moodleinternal, $eventfile);


### PR DESCRIPTION
Changing the namespace to "<component_type>_<component_name>" was necessary because mod plugins do not specify the plugin type in the component variable.