### PR TITLE
Generate a mod plugin type

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -1,0 +1,8 @@
+
+CREDITS
+
+
+- David Mudrak (https://github.com/moodlehq/moodle-mod_newmodule)
+- Justin Hunt (https://github.com/justinhunt/moodle-mod_newmodule/blob/master/lib.php)
+
+for their activity modules templates.

--- a/classes/local/skel/base.php
+++ b/classes/local/skel/base.php
@@ -64,6 +64,15 @@ class base {
         $this->data = $data;
     }
 
+    public function set_attribute($attribute) {
+
+        if (empty($this->data)) {
+            throw new coding_exception(get_string('skeletondatanotset', 'tool_pluginskel'));
+        }
+
+        $this->data['self'][$attribute] = true;
+    }
+
     /**
      * Render the file contents.
      *

--- a/classes/local/skel/lib_php_file.php
+++ b/classes/local/skel/lib_php_file.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provides tool_pluginskel\local\skel\lib_php_file class.
+ *
+ * @package     tool_pluginskel
+ * @subpackage  skel
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_pluginskel\local\skel;
+
+use tool_pluginskel\local\util\exception;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class representing the lib.php file.
+ *
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class lib_php_file extends php_library_file {
+
+    /**
+     * Set the data to be eventually rendered.
+     *
+     * @param array $data
+     */
+    public function set_data(array $data) {
+
+        parent::set_data($data);
+
+        $this->data['self']['component_name_all_caps'] = \core_text::strtoupper($this->data['component_name']);
+    }
+
+    /**
+     * Adds a feature supported by the plugin.
+     *
+     * @param string $feature The feature name.
+     */
+    public function add_supported_feature($feature) {
+
+        if (empty($this->data)) {
+            throw new coding_exception(get_string('skeletondatanotset', 'tool_pluginskel'));
+        }
+
+        if (empty($this->data['self']['supports'])) {
+            $this->data['self']['supports'] = array();
+        }
+
+        $this->data['self']['supports'][] = $feature;
+    }
+}

--- a/classes/local/skel/php_library_file.php
+++ b/classes/local/skel/php_library_file.php
@@ -15,15 +15,41 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Provides the plugin strings.
+ * Provides tool_pluginskel\local\skel\php_library_file class.
  *
  * @package     tool_pluginskel
- * @category    string
+ * @subpackage  skel
  * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_pluginskel\local\skel;
+
 defined('MOODLE_INTERNAL') || die();
 
-$string['pluginname'] = 'Moodle plugin skeleton generator';
-$string['skeletondatanotset'] = 'Skeleton data not set';
+/**
+ * Class representing a Moodle library file.
+ *
+ * Moodle library files contain functions and/or classes.
+ *
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class php_library_file extends php_internal_file {
+
+    /**
+     * Adds an array of functions.
+     *
+     * @param string[] $functions The name of the functions.
+     */
+    public function add_functions($functions) {
+
+        if (empty($this->data)) {
+            throw new coding_exception(get_string('skeletondatanotset', 'tool_pluginskel'));
+        }
+
+        foreach ($functions as $function) {
+            $this->data['self']['functions'][$function] = true;
+        }
+    }
+}

--- a/classes/local/skel/view_php_file.php
+++ b/classes/local/skel/view_php_file.php
@@ -15,15 +15,38 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Provides the plugin strings.
+ * Provides tool_pluginskel\local\skel\view_php_file class.
  *
  * @package     tool_pluginskel
- * @category    string
+ * @subpackage  skel
  * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_pluginskel\local\skel;
+
+use tool_pluginskel\local\util\exception;
+
 defined('MOODLE_INTERNAL') || die();
 
-$string['pluginname'] = 'Moodle plugin skeleton generator';
-$string['skeletondatanotset'] = 'Skeleton data not set';
+/**
+ * Class representing the view.php file.
+ *
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class view_php_file extends php_web_file {
+
+    /**
+     * Set the data to be eventually rendered.
+     *
+     * @param array $data
+     */
+    public function set_data(array $data) {
+
+        parent::set_data($data);
+
+        $firstcharacter = substr($this->data['component_name'], 0, 1);
+        $this->data['self']['component_name_first_character'] = $firstcharacter;
+    }
+}

--- a/classes/local/util/manager.php
+++ b/classes/local/util/manager.php
@@ -160,6 +160,12 @@ class manager {
         $this->prepare_file_skeleton('version.php', 'version_php_file', 'version');
         $this->prepare_file_skeleton('lang/en/'.$this->recipe['component'].'.php', 'lang_file', 'lang');
 
+        $plugintype = $this->recipe['component_type'];
+
+        if ($plugintype === 'mod') {
+            $this->prepare_mod_files();
+        }
+
         if ($this->should_have('readme')) {
             $this->prepare_file_skeleton('README.md', 'txt_file', 'readme');
         }
@@ -206,6 +212,100 @@ class manager {
 
         if ($this->should_have('events')) {
             $this->prepare_events();
+        }
+
+    }
+
+    /**
+     * Prepares the files for an activity module plugin.
+     */
+    protected function prepare_mod_files() {
+
+        $componentname = $this->recipe['component_name'];
+
+        $stringids = array(
+            $componentname.'name',
+            $componentname.'name_help',
+            $componentname.'settings',
+            $componentname.'fieldset',
+            'missingidandcmid',
+            'modulename',
+            'modulename_help',
+            'modulenameplural',
+            'nonewmodules',
+            'pluginadministration',
+            'view'
+        );
+
+        foreach ($stringids as $stringid) {
+
+            $found = false;
+            if (!empty($this->recipe['strings'])) {
+                foreach ($this->recipe['strings'] as $string) {
+                    if ($string['id'] === $stringid) {
+                        $found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!$found) {
+                $this->logger->warning("String id '$stringid' not set");
+            }
+        }
+
+        $this->prepare_file_skeleton('index.php', 'php_web_file', 'mod/index');
+        $this->prepare_file_skeleton('view.php', 'view_php_file', 'mod/view');
+        $this->prepare_file_skeleton('mod_form.php', 'php_internal_file', 'mod/mod_form');
+        $this->prepare_file_skeleton('lib.php', 'lib_php_file', 'mod/lib');
+
+        if ($this->should_have('gradebook')) {
+            $gradebookfunctions = array(
+                'scale_used',
+                'scale_used_anywhere',
+                'grade_item_update',
+                'grade_item_delete',
+                'update_grades'
+            );
+            $this->files['lib.php']->add_functions($gradebookfunctions);
+
+            $this->files['lib.php']->add_supported_feature('FEATURE_GRADE_HAS_GRADE');
+            $this->prepare_file_skeleton('grade.php', 'php_web_file', 'mod/grade');
+
+            $this->files['mod_form.php']->set_attribute('has_gradebook');
+        }
+
+        if ($this->should_have('file_area')) {
+            $fileareafunctions = array(
+                'get_file_areas',
+                'get_file_info',
+                'pluginfile'
+            );
+            $this->files['lib.php']->add_functions($fileareafunctions);
+        }
+
+        $this->files['lib.php']->add_supported_feature('FEATURE_MOD_INTRO');
+
+        // 'mod/<modname>:addinstance' and 'mod/<modname>:view' capabilities are recommended.
+        if (!$this->should_have('capabilities')) {
+            $this->logger->warning('Capabilities not defined');
+        }
+
+        if (!$this->should_have('observers')) {
+            $this->logger->warning('Observers not defined');
+        }
+
+        if (!$this->should_have('upgrade')) {
+            $this->logger->warning('Upgrade feature not defined');
+        }
+
+        // TODO: implement the backup_moodle2 feature.
+        if (!$this->should_have('backup_moodle2')) {
+            $this->logger->warning('Backup_moodle2 feature not defined');
+        }
+
+        if ($this->should_have('navigation')) {
+            $this->files['lib.php']->set_attribute('has_navigation');
         }
     }
 

--- a/skel/common/lib.mustache
+++ b/skel/common/lib.mustache
@@ -1,0 +1,11 @@
+{{!
+    lib.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Library of interface functions and constants.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}

--- a/skel/file/mod/grade.mustache
+++ b/skel/file/mod/grade.mustache
@@ -1,0 +1,26 @@
+{{!
+    grade.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Redirect the user to the appropiate submission related page.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ extratags }}
+ * @category    grade
+{{/ extratags }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+
+// Course module ID.
+$id = required_param('id', PARAM_INT);
+
+// Item number may be != 0 for activities that allow more than one grade per user.
+$itemnumber = optional_param('itemnumber', 0, PARAM_INT);
+
+// Graded user ID (optional).
+$userid = optional_param('userid', 0, PARAM_INT);
+
+// In the simplest case just redirect to the view page.
+redirect('view.php?id='.$id);

--- a/skel/file/mod/index.mustache
+++ b/skel/file/mod/index.mustache
@@ -1,0 +1,78 @@
+{{!
+    index.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Display information about all the {{ component }} modules in the requested course.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+
+require_once(__DIR__.'/lib.php');
+
+$id = required_param('id', PARAM_INT);
+
+$course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
+require_course_login($course);
+
+$coursecontext = context_course::instance($course->id);
+
+$event = \{{component_type}}_{{ component_name }}\event\course_module_instance_list_viewed::create(array(
+    'context' => $modulecontext
+));
+$event->add_record_snapshot('course', $course);
+$event->trigger();
+
+$PAGE->set_url('/mod/{{ component_name }}/index.php', array('id' => $id));
+$PAGE->set_title(format_string($course->fullname));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($coursecontext);
+
+echo $OUTPUT->header();
+
+$modulenameplural = get_string('modulenameplural', '{{ component }}');
+echo $OUTPUT->heading($modulenameplural);
+
+${{ component_name }}s = get_all_instances_in_course('{{ component_name }}', $course);
+
+if (empty(${{ component_name }}s)) {
+    notice(get_string('nonewmodules', '{{ component }}'), new moodle_url('/course/view.php', array('id' => $course->id)));
+}
+
+$table = new html_table();
+$table->attributes['class'] = 'generaltable mod_index';
+
+if ($course->format == 'weeks') {
+    $table->head  = array(get_string('week'), get_string('name'));
+    $table->align = array('center', 'left');
+} else if ($course->format == 'topics') {
+    $table->head  = array(get_string('topic'), get_string('name'));
+    $table->align = array('center', 'left', 'left', 'left');
+} else {
+    $table->head  = array(get_string('name'));
+    $table->align = array('left', 'left', 'left');
+}
+
+foreach (${{ component_name }}s as ${{ component_name }}) {
+    if (!${{ component_name }}->visible) {
+        $link = html_writer::link(
+            new moodle_url('/mod/{{ component_name }}/view.php', array('id' => ${{ component_name }}->coursemodule)),
+            format_string(${{ component_name }}->name, true),
+            array('class' => 'dimmed'));
+    } else {
+        $link = html_writer::link(
+            new moodle_url('/mod/{{ component_name }}/view.php', array('id' => ${{ component_name }}->coursemodule)),
+            format_string(${{ component_name }}->name, true));
+    }
+
+    if ($course->format == 'weeks' or $course->format == 'topics') {
+        $table->data[] = array(${{ component_name }}->section, $link);
+    } else {
+        $table->data[] = array($link);
+    }
+}
+
+echo html_writer::table($table);
+echo $OUTPUT->footer();

--- a/skel/file/mod/lib.mustache
+++ b/skel/file/mod/lib.mustache
@@ -1,0 +1,424 @@
+{{!
+    lib.php
+
+    * component
+    * copyright
+}}
+{{< common/lib }}
+{{/ common/lib }}
+
+/**
+ * Return if the plugin supports $feature.
+ *
+ * @param string $feature Constant representing the feature.
+ * @return true | null True if the feature is supported, null otherwise.
+ */
+function {{ component }}_supports($feature) {
+    switch ($feature) {
+        {{# self.supports }}
+        case {{ . }}:
+            return true;
+        {{/ self.supports }}
+        default:
+            return null;
+    }
+}
+
+/**
+ * Saves a new instance of the {{ component }} into the database.
+ *
+ * Given an object containing all the necessary data, (defined by the form
+ * in mod_form.php) this function will create a new instance and return the id
+ * number of the instance.
+ *
+ * @param object $moduleinstance An object from the form.
+ * @param mod_{{ component_name }}_mod_form $mform The form.
+ * @return int The id of the newly inserted record.
+ */
+function {{ component }}_add_instance($moduleinstance, $mform = null) {
+    global $DB;
+
+    $moduleinstance->timecreated = time();
+
+    $id = $DB->insert_record('{{ component }}', $moduleinstance);
+
+    return $id;
+}
+
+/**
+ * Updates an instance of the {{ component }} in the database.
+ *
+ * Given an object containing all the necessary data (defined in mod_form.php),
+ * this function will update an existing instance with new data.
+ *
+ * @param object $moduleinstance An object from the form in mod_form.php.
+ * @param mod_{{ component_name }}_mod_form $mform The form.
+ * @return bool True if successful, false otherwise.
+ */
+function {{ component }}_update_instance($moduleinstance, $mform = null) {
+    global $DB;
+
+    $moduleinstance->timemodified = time();
+    $moduleinstance->id = $moduleinstance->instance;
+
+    return $DB->update_record('{{ component }}', $moduleinstance);
+}
+
+/**
+ * Removes an instance of the {{ component }} from the database.
+ *
+ * @param int $id Id of the module instance.
+ * @return bool True if successful, false on failure.
+ */
+function {{ component }}_delete_instance($id) {
+    global $DB;
+
+    $exists = $DB->get_record('{{ component }}', array('id' => $id));
+    if (!$exists) {
+        return false;
+    }
+
+    $DB->delete_records('{{ component }}', array('id' => $id));
+
+    return true;
+}
+{{# self.functions.user_outline }}
+
+/**
+ * Returns a small object with summary information about what a user has done
+ * with a given particular instance of this module. Used for user activity
+ * reports.
+
+ * @param stdClass $course The course record.
+ * @param stdClas $user The user record.
+ * @param cm_info | stdClass $mod The course module info object or record.
+ * @param stdClass $moduleinstance The {{ component }} instance record.
+ * @return stdClass | null.
+ */
+function {{ component }}_user_outline($course, $user, $mod, $moduleinstance) {
+    $return = new stdClass();
+
+    // The time they did it.
+    $return->time = 0;
+
+    // A short text description;
+    $return->info = '';
+
+    return $return;
+}
+{{/ self.functions.user_outline }}
+{{# self.functions.user_complete }}
+
+/**
+ * Prints a detailed representation of what a user has done with a given
+ * particular instance of this module, for user activity reports.
+ *
+ * @param stdClass $course The current course record.
+ * @param stdClass $user The user record.
+ * @param cm_info $mod Course module info.
+ * @param stdClass $moduleinstance The {{ component }} instance record.
+ */
+function {{ component }}_user_complete($course, $user, $mod, $moduleinstance) {
+    return;
+}
+{{/ self.functions.user_complete }}
+{{# self.functions.print_recent_activity }}
+
+/**
+ * Given a course and a time, this module should find recent activity that has
+ * occurred in {{ component }} activities and print it out.
+ *
+ * @param stdClass $course The course record.
+ * @param bool $viewfullnames Should we display full names.
+ * @param int $timestart Print activity since this timestamp.
+ * @return bool True if anything was printed, false otherwiese.
+ */
+function {{ component }}_print_recent_activity($course, $viewfullnames, $timestart) {
+    return false;
+}
+{{/ self.functions.print_recent_activity}}
+{{# self.functions.get_recent_mod_activity }}
+
+/**
+ * Prepares the recent activity data.
+ *
+ * This callback function is supposed to populate the passed array with custom
+ * activity records. These records are then rendered into HTML via
+ * {@link newmodule_print_recent_mod_activity()}.
+ *
+ * @param array $activities Numerically indexed array of objects with added 'cmid' property.
+ * @param int $index The index in the $activities to use for the next record.
+ * @param int $timestart Append activity since this time.
+ * @param int $courseid The id of the course the report is for.
+ * @param int $cmid Course module id.
+ * @param int $userid Check for a particular user's activity only, defaults to 0 (all users).
+ * @param int $groupid Check for a particular group's activity only, defaults to 0 (all groups).
+ */
+function {{ component }}_get_recent_mod_activity(&$activities, &$index, $timestart, $courseid, $cmid, $userid=0, $groupid=0) {
+    return;
+}
+{{/ self.functions.get_recent_mod_activity }}
+{{# self.functions.print_recent_mod_activity }}
+
+/**
+ * Prints single activity item prepared by {@link {{ component }}_get_recent_mod_activity()}.
+ *
+ * @param stdClass $activity Activity record with added 'cmid' property.
+ * @param int $courseid The id of the course the report is for.
+ * @param bool $detail Print detailed report.
+ * @param array $modnames As returned by {@link get_module_types_names()}.
+ * @param bool $viewfullnames Display users' full names.
+ */
+function {{ component }}_print_recent_mod_activity($activity, $courseid, $detail, $modnames, $viewfullnames) {
+    return;
+}
+{{/ self.functions.print_recent_mod_activity }}
+{{# self.functions.get_extra_capabilities }}
+
+/**
+ * Returns all other capabilities used in the module.
+ *
+ * For example, this could be array('moodle/site:accessallgroups') if the
+ * module uses that capability.
+ *
+ * @return string[].
+ */
+function {{ component }}_get_extra_capabilities() {
+    return array();
+}
+{{/ self.functions.get_extra_capabilities }}
+{{!
+
+    Start of gradebook feature functions.
+
+}}
+{{# self.functions.scale_used }}
+
+/**
+ * Is a given scale used by the instance of {{ component }}?
+ *
+ * This function returns if a scale is being used by one {{ component }}
+ * if it has support for grading and scales.
+ *
+ * @param int $moduleinstanceid ID of an instance of this module.
+ * @param int $scaleid ID of the scale.
+ * @return bool True if the scale is used by the given {{ component }} instance.
+ */
+function {{ component }}_scale_used($moduleinstanceid, $scaleid) {
+    global $DB;
+
+    if ($scaleid && $DB->record_exists('{{ component }}', array('id' => $moduleinstanceid, 'grade' => -$scaleid))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+{{/ self.functions.scale_used }}
+{{# self.functions.scale_used_anywhere }}
+
+/**
+ * Checks if scale is being used by any instance of {{ component }}.
+ *
+ * This is used to find out if scale used anywhere.
+ *
+ * @param int $scaleid ID of the scale.
+ * @return bool True if the scale is used by any {{ component }} instance.
+ */
+function {{ component }}_scale_used_anywhere($scaleid) {
+    global $DB;
+
+    if ($scaleid and $DB->record_exists('{{ component }}', array('grade' => -$scaleid))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+{{/ self.functions.scale_used_anywhere }}
+{{# self.functions.grade_item_update }}
+
+/**
+ * Creates or updates grade item for the given {{ component }} instance.
+ *
+ * Needed by {@link grade_update_mod_grades()}.
+ *
+ * @param stdClass $moduleinstance Instance object with extra cmidnumber and modname property.
+ * @param bool $reset Reset grades in the gradebook.
+ * @return void.
+ */
+function {{ component }}_grade_item_update($moduleinstance, $reset=false) {
+    global $CFG;
+    require_once($CFG->libdir.'/gradelib.php');
+
+    $item = array();
+    $item['itemname'] = clean_param($moduleinstance->name, PARAM_NOTAGS);
+    $item['gradetype'] = GRADE_TYPE_VALUE;
+
+    if ($moduleinstance->grade > 0) {
+        $item['gradetype'] = GRADE_TYPE_VALUE;
+        $item['grademax']  = $moduleinstance->grade;
+        $item['grademin']  = 0;
+    } else if ($moduleinstance->grade < 0) {
+        $item['gradetype'] = GRADE_TYPE_SCALE;
+        $item['scaleid']   = -$moduleinstance->grade;
+    } else {
+        $item['gradetype'] = GRADE_TYPE_NONE;
+    }
+    if ($reset) {
+        $item['reset'] = true;
+    }
+
+    grade_update('{{ component_root }}/{{ component_name }}', $moduleinstance->course, 'mod', '{{ component }}', $moduleinstance->id, 0, null, $item);
+}
+{{/ self.functions.grade_item_update }}
+{{# self.functions.grade_item_delete }}
+
+/**
+ * Delete grade item for given {{ component }} instance.
+ *
+ * @param stdClass $moduleinstance Instance object.
+ * @return grade_item.
+ */
+function {{ component }}_grade_item_delete($moduleinstance) {
+    global $CFG;
+    require_once($CFG->libdir.'/gradelib.php');
+
+    return grade_update('{{ component_root }}/{{ component_name }}', $moduleinstance->course, 'mod', '{{ component_name }}',
+                        $moduleinstance->id, 0, null, array('deleted' => 1));
+}
+{{/ self.functions.grade_item_delete }}
+{{# self.functions.update_grades }}
+
+/**
+ * Update {{ component }} grades in the gradebook.
+ *
+ * Needed by {@link grade_update_mod_grades()}.
+ *
+ * @param stdClass $moduleinstance Instance object with extra cmidnumber and modname property.
+ * @param int $userid Update grade of specific user only, 0 means all participants.
+ */
+function {{ component }}_update_grades($moduleinstance, $userid = 0) {
+    global $CFG, $DB;
+    require_once($CFG->libdir.'/gradelib.php');
+
+    // Populate array of grade objects indexed by userid.
+    $grades = array();
+    grade_update('{{ component_root }}/{{ component_name }}', $moduleinstance->course, 'mod', '{{ component }}', $moduleinstance->id, 0, $grades);
+}
+{{/ self.functions.update_grades }}
+{{!
+
+    End of gradebook feature functions.
+
+}}
+{{!
+
+    Start of file_area feature functions.
+
+}}
+{{# self.functions.get_file_areas }}
+
+/**
+ * Returns the lists of all browsable file areas within the given module context.
+ *
+ * The file area 'intro' for the activity introduction field is added automatically
+ * by {@link file_browser::get_file_info_context_module()}.
+ *
+ * @package     {{ component }}
+ * @category    files
+ *
+ * @param stdClass $course.
+ * @param stdClass $cm.
+ * @param stdClass $context.
+ * @return string[].
+ */
+function {{ component }}_get_file_areas($course, $cm, $context) {
+    return array();
+}
+{{/ self.functions.get_file_areas }}
+{{# self.functions.get_file_info }}
+
+/**
+ * File browsing support for {{ component }} file areas.
+ *
+ * @package     {{ component }}
+ * @category    files
+ *
+ * @param file_browser $browser.
+ * @param array $areas.
+ * @param stdClass $course.
+ * @param stdClass $cm.
+ * @param stdClass $context.
+ * @param string $filearea.
+ * @param int $itemid.
+ * @param string $filepath.
+ * @param string $filename.
+ * @return file_info Instance or null if not found.
+ */
+function {{ component }}_get_file_info($browser, $areas, $course, $cm, $context, $filearea, $itemid, $filepath, $filename) {
+    return null;
+}
+{{/ self.functions.get_file_info }}
+{{# self.functions.pluginfile }}
+
+/**
+ * Serves the files from the {{ component }} file areas.
+ *
+ * @package     {{ component }}
+ * @category    files
+ *
+ * @param stdClass $course The course object.
+ * @param stdClass $cm The course module object.
+ * @param stdClass $context The {{ component }}'s context.
+ * @param string $filearea The name of the file area.
+ * @param array $args Extra arguments (itemid, path).
+ * @param bool $forcedownload Whether or not force download.
+ * @param array $options Additional options affecting the file serving.
+ */
+function {{ component }}_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, $options = array()) {
+    global $DB, $CFG;
+
+    if ($context->contextlevel != CONTEXT_MODULE) {
+        send_file_not_found();
+    }
+
+    require_login($course, true, $cm);
+    send_file_not_found();
+}
+{{/ self.functions.pluginfile }}
+{{!
+
+    End of file_area specific functions.
+
+}}
+{{!
+
+    Start of navigation specific functions.
+
+}}
+{{# self.has_navigation }}
+
+/**
+ * Extends the global navigation tree by adding {{ component }} nodes if there is a relevant content.
+ *
+ * This can be called by an AJAX request so do not rely on $PAGE as it might not be set up properly.
+ *
+ * @param navigation_node ${{ component_name}}node An object representing the navigation tree node.
+ * @param stdClass $course.
+ * @param stdClass $module.
+ * @param cm_info $cm.
+ */
+function {{ component }}_extend_navigation(${{ component_name }}node, $course, $module, $cm) {
+}
+
+/**
+ * Extends the settings navigation with the {{ component }} settings.
+ *
+ * This function is called when the context for the page is a {{ component }} module.
+ * This is not called by AJAX so it is safe to rely on the $PAGE.
+ *
+ * @param settings_navigation $settingsnav {@link settings_navigation}
+ * @param navigation_node ${{ component_name }}node {@link navigation_node}
+ */
+function {{ component }}_extend_settings_navigation($settingsnav, ${{ component_name }}node = null) {
+}
+{{/ self.has_navigation }}

--- a/skel/file/mod/mod_form.mustache
+++ b/skel/file/mod/mod_form.mustache
@@ -1,0 +1,71 @@
+{{!
+    grade.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}The main {{ component }} configuration form.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+
+require_once($CFG->dirroot.'/course/moodleform_mod.php');
+
+/**
+ * Module instance settings form.
+ *
+ * @package    {{ component }}
+ * @copyright  {{ copyright }}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_{{ component_name }}_mod_form extends moodleform_mod {
+
+    /**
+     * Defines forms elements
+     */
+    public function definition() {
+        global $CFG;
+
+        $mform = $this->_form;
+
+        // Adding the "general" fieldset, where all the common settings are showed.
+        $mform->addElement('header', 'general', get_string('general', 'form'));
+
+        // Adding the standard "name" field.
+        $mform->addElement('text', 'name', get_string('{{ component_name }}name', '{{ component }}'), array('size' => '64'));
+
+        if (!empty($CFG->formatstringstriptags)) {
+            $mform->setType('name', PARAM_TEXT);
+        } else {
+            $mform->setType('name', PARAM_CLEANHTML);
+        }
+
+        $mform->addRule('name', null, 'required', null, 'client');
+        $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
+        $mform->addHelpButton('name', '{{ component_name }}name', '{{ component }}');
+
+        // Adding the standard "intro" and "introformat" fields.
+        if ($CFG->branch >= 29) {
+            $this->standard_intro_elements();
+        } else {
+            $this->add_intro_editor();
+        }
+
+        // Adding the rest of {{ component }} settings, spreading all them into this fieldset
+        // ... or adding more fieldsets ('header' elements) if needed for better logic.
+        $mform->addElement('static', 'label1', '{{ component_name }}settings', get_string('{{ component_name }}settings', '{{ component }}'));
+        $mform->addElement('header', '{{ component_name }}fieldset', get_string('{{ component_name }}fieldset', '{{ component }}'));
+{{# self.has_gradebook }}
+
+        // Add standard grading elements.
+        $this->standard_grading_coursemodule_elements();
+{{/ self.has_gradebook }}
+
+        // Add standard elements.
+        $this->standard_coursemodule_elements();
+
+        // Add standard buttons.
+        $this->add_action_buttons();
+    }
+}

--- a/skel/file/mod/view.mustache
+++ b/skel/file/mod/view.mustache
@@ -1,0 +1,51 @@
+{{!
+    view.php
+
+    * component
+    * copyright
+}}
+{{< common/boilerplate_php }}
+{{$ description }}Prints an instance of {{ component }}.{{/ description }}
+{{$ package }}{{ component }}{{/ package }}
+{{$ copyright }}{{ copyright }}{{/ copyright }}
+{{/ common/boilerplate_php }}
+require_once(__DIR__.'/lib.php');
+
+// Course_module ID, or
+$id = optional_param('id', 0, PARAM_INT);
+
+// ... module instance id.
+${{ self.component_name_first_character }}  = optional_param('{{ self.component_name_first_character }}', 0, PARAM_INT);
+
+if ($id) {
+    $cm             = get_coursemodule_from_id('{{ component_name }}', $id, 0, false, MUST_EXIST);
+    $course         = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+    $moduleinstance = $DB->get_record('{{ component }}', array('id' => $cm->instance), '*', MUST_EXIST);
+} else if (${{ self.component_name_first_character }}) {
+    $moduleinstance = $DB->get_record('{{ component }}', array('id' => $n), '*', MUST_EXIST);
+    $course         = $DB->get_record('course', array('id' => $moduleinstance->course), '*', MUST_EXIST);
+    $cm             = get_coursemodule_from_instance('{{ component_name }}', $moduleinstance->id, $course->id, false, MUST_EXIST);
+} else {
+    print_error(get_string('missingidandcmid', {{ component }}));
+}
+
+require_login($course, true, $cm);
+
+$modulecontext = context_module::instance($cm->id);
+
+$event = \{{component_type}}_{{ component_name }}\event\course_module_viewed::create(array(
+    'objectid' => $moduleinstance->id,
+    'context' => $modulecontext
+));
+$event->add_record_snapshot('course', $course);
+$event->add_record_snapshot('{{ component}}', $moduleinstance);
+$event->trigger();
+
+$PAGE->set_url('/mod/{{ component_name }}/view.php', array('id' => $cm->id));
+$PAGE->set_title(format_string($moduleinstance->name));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($modulecontext);
+
+echo $OUTPUT->header();
+
+echo $OUTPUT->footer();

--- a/tests/mod_test.php
+++ b/tests/mod_test.php
@@ -1,0 +1,374 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing tests for generating an activity module.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+use tool_pluginskel\local\util\manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/setuplib.php');
+require_once($CFG->dirroot . '/' . $CFG->admin . '/tool/pluginskel/vendor/autoload.php');
+
+/**
+ * Activity module test class.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2016 Alexandru Elisei alexandru.elisei@gmail.com
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_pluginskel_mod_testcase extends advanced_testcase {
+
+    /** @var string[] The test recipe. */
+    protected static $recipe = array(
+        'component' => 'modtest',
+        'name'      => 'Mod test',
+        'copyright' => '2016 Alexandru Elisei <alexandru.elisei@gmail.com>',
+        'features'  => array(
+            'settings' => true,
+            'upgrade' => true,
+            'uninstall' => true,
+            'install' => true,
+        ),
+        'events' => array(
+            array(
+                'eventname' => 'course_module_instance_list_viewed',
+                'extends' => '\core\event\course_module_instance_list_viewed'
+            ),
+            array(
+                'eventname' => 'course_module_viewed',
+                'extends' => '\core\event\course_module_viewed'
+            ),
+        ),
+        'observers' => array(
+            array(
+                'eventname' => '\mod_test\event\course_module_instance_list_viewed',
+                'callback' => '\mod_test\observer::course_module_instance_list_viewed'
+            ),
+            array(
+                'eventname' => '\mod_test\event\course_module_viewed',
+                'callback' => '\mod_test\observer::course_module_viewed'
+            )
+        ),
+        'capabilities' => array(
+            array(
+                'name' => 'addinstance',
+                'riskbitmask' => 'RISK_XSS',
+                'captype' => 'write',
+                'contextlevel' => 'CONTEXT_COURSE',
+                'archetypes' => array(
+                    array(
+                        'role' => 'manager',
+                        'permission' => 'CAP_ALLOW'
+                    ),
+                    array(
+                        'role' => 'editingteacher',
+                        'permission' => 'CAP_ALLOW'
+                    )
+                ),
+                'clonepermissionsfrom' => 'moodle/course:manageactivities'
+            ),
+            array(
+                'name' => 'view',
+                'captype' => 'read',
+                'contextlevel' => 'CONTEXT_MODULE',
+                'archetypes' => array(
+                    array(
+                        'role' => 'guest',
+                        'permission' => 'CAP_ALLOW'
+                    ),
+                    array(
+                        'role' => 'student',
+                        'permission' => 'CAP_ALLOW'
+                    ),
+                    array(
+                        'role' => 'teacher',
+                        'permission' => 'CAP_ALLOW'
+                    ),
+                    array(
+                        'role' => 'editingteacher',
+                        'permission' => 'CAP_ALLOW'
+                    ),
+                ),
+                'clonepermissionsfrom' => 'moodle/course:manageactivities'
+            )
+        )
+    );
+
+    /**
+     * Tests creating the basic files.
+     */
+    public function test_mod_files() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+
+        $this->assertArrayHasKey('lib.php', $files);
+        $this->assertArrayHasKey('mod_form.php', $files);
+        $this->assertArrayHasKey('view.php', $files);
+        $this->assertArrayHasKey('index.php', $files);
+    }
+
+    /**
+     * Tests the file lib.php.
+     */
+    public function test_lib_php() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('lib.php', $files);
+        $libfile = $files['lib.php'];
+
+        $description = 'Library of interface functions and constants.';
+        $this->assertContains($description, $libfile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die()";
+        $this->assertContains($moodleinternal, $libfile);
+
+        $addinstance = 'function '.$recipe['component'].'_add_instance($moduleinstance, $mform = null)';
+        $this->assertContains($addinstance, $libfile);
+
+        $updateinstance = 'function '.$recipe['component'].'_update_instance($moduleinstance, $mform = null)';
+        $this->assertContains($updateinstance, $libfile);
+
+        $deleteinstance = 'function '.$recipe['component'].'_delete_instance($id)';
+        $this->assertContains($deleteinstance, $libfile);
+    }
+
+    /**
+     * Tests the file mod_form.php.
+     */
+    public function test_mod_form_php() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('mod_form.php', $files);
+        $modformfile = $files['mod_form.php'];
+
+        $description = 'The main '.$recipe['component'].' configuration form.';
+        $this->assertContains($description, $modformfile);
+
+        $moodleinternal = "defined('MOODLE_INTERNAL') || die()";
+        $this->assertContains($moodleinternal, $modformfile);
+
+        $formclass = 'class mod_'.$recipe['component'].'_mod_form extends moodleform_mod';
+        $this->assertContains($formclass, $modformfile);
+    }
+
+    /**
+     * Tests the file view.php.
+     */
+    public function test_view_php() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('view.php', $files);
+        $viewfile = $files['view.php'];
+
+        $description = 'Prints an instance of '.$recipe['component'].'.';
+        $this->assertContains($description, $viewfile);
+
+        $requireconfig = "require(__DIR__.'/../../config.php')";
+        $this->assertContains($requireconfig, $viewfile);
+
+        $requirelogin = 'require_login($course, true, $cm)';
+        $this->assertContains($requirelogin, $viewfile);
+
+        $seturl = "\$PAGE->set_url('/mod/".$recipe['component']."/view.php', array('id' => \$cm->id))";
+        $this->assertContains($seturl, $viewfile);
+
+        $header = 'echo $OUTPUT->header()';
+        $this->assertContains($header, $viewfile);
+
+        $footer = 'echo $OUTPUT->footer()';
+        $this->assertContains($footer, $viewfile);
+    }
+
+    /**
+     * Tests the file index.php.
+     */
+    public function test_index_php() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('index.php', $files);
+        $indexfile = $files['index.php'];
+
+        $description = 'Display information about all the '.$recipe['component'].' modules in the requested course.';
+        $this->assertContains($description, $indexfile);
+
+        $requireconfig = "require(__DIR__.'/../../config.php')";
+        $this->assertContains($requireconfig, $indexfile);
+
+        $course = "\$DB->get_record('course', array('id' => \$id), '*', MUST_EXIST)";
+        $this->assertContains($course, $indexfile);
+
+        $requirecourselogin = 'require_course_login($course)';
+        $this->assertContains($requirecourselogin, $indexfile);
+
+        $seturl = "\$PAGE->set_url('/mod/".$recipe['component']."/index.php', array('id' => \$id))";
+        $this->assertContains($seturl, $indexfile);
+
+        $header = 'echo $OUTPUT->header()';
+        $this->assertContains($header, $indexfile);
+
+        $footer = 'echo $OUTPUT->footer()';
+        $this->assertContains($footer, $indexfile);
+    }
+
+    /**
+     * Tests creating the 'gradebook' feature.
+     */
+    public function test_gradebook_feature() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $recipe['features']['gradebook'] = true;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+
+        $this->assertArrayHasKey('lib.php', $files);
+        $this->assertArrayHasKey('grade.php', $files);
+        $this->assertArrayHasKey('mod_form.php', $files);
+
+        $modformfile = $files['mod_form.php'];
+
+        $standardgradingelements = '$this->standard_grading_coursemodule_elements()';
+        $this->assertContains($standardgradingelements, $modformfile);
+
+        $libfile = $files['lib.php'];
+
+        $this->assertRegExp('/case FEATURE_GRADE_HAS_GRADE:\s+return true/', $libfile);
+
+        $scaleused = 'function '.$recipe['component'].'_scale_used($moduleinstanceid, $scaleid)';
+        $this->assertContains($scaleused, $libfile);
+
+        $scaleusedanywhere = 'function '.$recipe['component'].'_scale_used_anywhere($scaleid)';
+        $this->assertContains($scaleusedanywhere, $libfile);
+
+        $gradeitemupdate = 'function '.$recipe['component'].'_grade_item_update($moduleinstance, $reset=false)';
+        $this->assertContains($gradeitemupdate, $libfile);
+
+        $gradeitemdelete = 'function '.$recipe['component'].'_grade_item_delete($moduleinstance)';
+        $this->assertContains($gradeitemdelete, $libfile);
+
+        $updategrades = 'function '.$recipe['component'].'_update_grades($moduleinstance, $userid = 0)';
+        $this->assertContains($updategrades, $libfile);
+
+        $gradefile = $files['grade.php'];
+
+        $description = 'Redirect the user to the appropiate submission related page.';
+        $this->assertContains($description, $gradefile);
+    }
+
+    /**
+     * Tests creating the 'file_area' feature.
+     */
+    public function test_file_area_feature() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $recipe['features']['file_area'] = true;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+
+        $this->assertArrayHasKey('lib.php', $files);
+        $libfile = $files['lib.php'];
+
+        $getfileareas = 'function '.$recipe['component'].'_get_file_areas($course, $cm, $context)';
+        $this->assertContains($getfileareas, $libfile);
+
+        $getfileinfo = 'function '.$recipe['component'].'_get_file_info($browser, $areas, $course, $cm, $context, $filearea, $itemid, $filepath, $filename)';
+        $this->assertContains($getfileinfo, $libfile);
+
+        $pluginfile = 'function '.$recipe['component'].'_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, $options = array())';
+        $this->assertContains($pluginfile, $libfile);
+    }
+
+    /**
+     * Tests creating the 'navigation' feature.
+     */
+    public function test_navigation_feature() {
+        $logger = new Logger('modtest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $recipe['features']['navigation'] = true;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+
+        $this->assertArrayHasKey('lib.php', $files);
+        $libfile = $files['lib.php'];
+
+        $extendnavigationargs = '$'.$recipe['component'].'node, $course, $module, $cm';
+        $extendnavigation = 'function '.$recipe['component'].'_extend_navigation('.$extendnavigationargs.')';
+        $this->assertContains($extendnavigation, $libfile);
+
+        $extendsettingsargs = '$settingsnav, $'.$recipe['component'].'node = null';
+        $extendsettings = 'function '.$recipe['component'].'_extend_settings_navigation('.$extendsettingsargs.')';
+        $this->assertContains($extendsettings, $libfile);
+    }
+}


### PR DESCRIPTION
I know this is a huge pull request, but I haven't figured out a way to split it into smaller chunks.

I've actually generated a mod plugin and tested it in my Moodle installation (I've used the db/install.xml file from [here](https://github.com/moodlehq/moodle-mod_newmodule)), it works.

I have a question though: from where is the index.php file accessed? I haven't managed to find any information about that.

Here's the recipe that will generate a working mod plugin:
```
## Plugin maturity level
maturity: MATURITY_BETA

## Copyright holder(s) of the generated files and classes.
copyright: 2016 Alexandru Elisei <alexandru.elisei@gmail.com>, David Mudrák <david@moodle.com>

## Features flags can control generation of optional files/code fragments.
features:
  #readme: true
  #license: true
  settings: true
  upgrade: true
  uninstall: true
  install: true

  ## Creates the gradebook related functions. Adds FEATURE_GRADE_HAS_GRADE.
  ## The file grade.php is also created.
  ## This feature is only generated in the context of a mod plugin.
  gradebook: true

  ## Creates the files API related function.
  ## Adds FEATURE_MOD_INTRO.
  ## This feature is only generated in the context of a mod plugin.
  file_area: true

  ## Creates the functions <modulename>_extend_navigation() and
  ## <modulename>_extend_settings_navigation() in lib.php.
  navigation: true

events:
  - eventname: course_module_instance_list_viewed
    extends: \core\event\course_module_instance_list_viewed
  - eventname: course_module_viewed
    extends: \core\event\course_module_viewed

observers:
  - eventname: \mod_test\event\course_module_instance_list_viewed
    callback: \mod_test\observer::course_module_instance_list_viewed
  - eventname: \mod_test\event\course_module_viewed
    callback: \mod_test\observer::course_module_viewed

capabilities:

  - name: addinstance
    riskbitmask: RISK_XSS
    captype: write
    contextlevel: CONTEXT_COURSE
    archetypes:
      - role: manager
        permission: CAP_ALLOW
      - role: editingteacher
        permission: CAP_ALLOW
    clonepermissionsfrom: moodle/course:manageactivities

  - name: view
    captype: read
    contextlevel: CONTEXT_MODULE
    archetypes:
      - role: guest
        permission: CAP_ALLOW
      - role: student
        permission: CAP_ALLOW
      - role: teacher
        permission: CAP_ALLOW
      - role: editingteacher
        permission: CAP_ALLOW

strings:
    - id: modulenameplural
      text: newmodules
    - id: modulename_help
      text: Use the newmodule module for...
    - id: newmodulefieldset
      text: Custom example fieldset.
    - id: newmodulename
      text: newmodule name
    - id: newmodulename_help
      text: This is the content of the help tooltip associated with the newmodulename field. Markdown syntax is supported.
    - id: modulename
      text: newmodule
    - id: pluginadministration
      text: newmodule administration
    - id: newmodulesettings
      text: Settings
    - id: missingidandcmid
      text: Missing id and cmid
    - id: nonewmodules
      text: No newmodules
    - id: view
      text: View
```