### PR TITLE
Update alphabetically component select for viewing purposes

### DIFF
--- a/classes/step0_form.php
+++ b/classes/step0_form.php
@@ -46,6 +46,7 @@ class tool_pluginskel_step0_form extends moodleform {
         $mform->setExpanded('manualhdr', true);
 
         $plugintypes = tool_pluginskel\local\util\manager::get_plugintype_names();
+        asort($plugintypes);
         $mform->addElement('select', 'componenttype', get_string('componenttype', 'tool_pluginskel'), $plugintypes);
         $mform->addHelpButton('componenttype', 'componenttype', 'tool_pluginskel');
 


### PR DESCRIPTION
Updating the component select might be more user friendly for users so nobody needs to check the entire component list.