### PR TITLE
Make pluginname readable on Manage Authentication page

### DIFF
--- a/skel/file/auth/auth.mustache
+++ b/skel/file/auth/auth.mustache
@@ -24,6 +24,15 @@ require_once($CFG->libdir.'/authlib.php');
 class auth_plugin_{{ component_name }} extends auth_plugin_base {
 
     /**
+     * Type of authentication provided. Used on the "Manage Authentication"
+     * page (/admin/settings.php?section=manageauths) to find value of
+     * pluginname string.
+     * 
+     * @var string
+     */
+    public $authtype = '{{ component_name }}';
+
+    /**
      * Returns true if the username and password work and false if they are
      * wrong or don't exist.
      *


### PR DESCRIPTION
This commit adds the public $authtype attribute to the auth_plugin_&lt;name&gt;
class which is used to obtain the plugin name on the "Manage
Authentication" page. Otherwise, only [[pluginname]] is shown in the
"Name" column of the plugins table.