### PR TITLE
Fixes error in string referenced from extenal repository

### DIFF
--- a/skel/file/cli.mustache
+++ b/skel/file/cli.mustache
@@ -32,7 +32,7 @@ Please include an example of usage.
 
 if ($unrecognized) {
     $unrecognized = implode("\n\t", $unrecognized);
-    cli_error(get_string('cliunknownoption', 'admin', $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized);
 }
 
 if ($options['help']) {


### PR DESCRIPTION
The string referenced from moodle repository file https://github.com/moodle/moodle/blob/f2fc4a9fa16e9a6bd3c462434e50d60aa73c1f2b/install/lang/en/admin.php#L39 should be `cliunknowoption` and not `cliunknownoption`. The same is true in other languages' admin files as well.
@mudrd8mz please review. Thanks!