### PR TITLE
Add an option to generate a basic .travis.yml for automated testing

### DIFF
--- a/classes/local/util/manager.php
+++ b/classes/local/util/manager.php
@@ -243,6 +243,7 @@ class manager {
         $featuresvars[] = array('name' => 'license', 'type' => 'boolean', 'default' => true);
         $featuresvars[] = array('name' => 'upgrade', 'type' => 'boolean');
         $featuresvars[] = array('name' => 'upgradelib', 'type' => 'boolean');
+        $featuresvars[] = array('name' => 'ci', 'type' => 'boolean');
 
         $capabilities = array(
             array('name' => 'capabilities', 'type' => 'numeric-array', 'values' => array(
@@ -478,6 +479,10 @@ class manager {
 
         if ($this->has_common_feature('capabilities')) {
             $this->prepare_capabilities();
+        }
+
+        if ($this->has_common_feature('ci')) {
+            $this->prepare_file_skeleton('.travis.yml', 'txt_file', 'travis');
         }
 
         if ($this->has_common_feature('settings')) {

--- a/lang/en/tool_pluginskel.php
+++ b/lang/en/tool_pluginskel.php
@@ -253,6 +253,8 @@ $string['events_extends'] = 'Extends';
 $string['events_extends_help'] = 'The name of the base event that the event extends.';
 $string['events_extends_link'] = 'https://docs.moodle.org/dev/Event_2';
 
+$string['features_ci'] = 'Travis CI configuration';
+$string['features_ci_help'] = 'Generate a .travis.yml file that configures automated testing of GitHub repositories.';
 $string['features_install'] = 'Install';
 $string['features_install_help'] = 'Generate the file db/install.php';
 $string['features_license'] = 'License';

--- a/skel/file/travis.mustache
+++ b/skel/file/travis.mustache
@@ -1,0 +1,55 @@
+{{!
+    .travis.yml,
+    as taken from https://github.com/moodlehq/moodle-plugin-ci/blob/d32fbdd2570c119ee84de233e31f6e0e61c018b5/.travis.dist.yml
+
+    * component
+    * copyright
+}}
+language: php
+
+addons:
+  postgresql: "9.6"
+
+services:
+  - mysql
+  - postgresql
+  - docker
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.npm
+
+php:
+ - 7.2
+ - 7.3
+ - 7.4
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_39_STABLE
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci savepoints
+  - moodle-plugin-ci mustache
+  - moodle-plugin-ci grunt
+  - moodle-plugin-ci phpdoc
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat

--- a/tests/ci_test.php
+++ b/tests/ci_test.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing tests for the 'ci' feature.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2020 Jan Dageförde <jan.dagefoerde@googlemail.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+use tool_pluginskel\local\util\manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/setuplib.php');
+require_once($CFG->dirroot . '/' . $CFG->admin . '/tool/pluginskel/vendor/autoload.php');
+
+/**
+ * CI test class.
+ *
+ * @package     tool_pluginskel
+ * @copyright   2020 Jan Dageförde <jan.dagefoerde@googlemail.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_pluginskel_ci_testcase extends advanced_testcase {
+
+    /** @var string[] The test recipe. */
+    protected static $recipe = array(
+        'component' => 'local_citest',
+        'name'      => 'CI test',
+        'copyright' => '2020 Jan Dageförde <jan.dagefoerde@googlemail.com>',
+        'features'  => array(
+            'ci' => true
+        )
+    );
+
+    /**
+     * Test creating the .travis.yml file.
+     */
+    public function test_ci() {
+        $logger = new Logger('citest');
+        $logger->pushHandler(new NullHandler());
+        $manager = manager::instance($logger);
+
+        $recipe = self::$recipe;
+        $manager->load_recipe($recipe);
+        $manager->make();
+
+        $files = $manager->get_files_content();
+        $this->assertArrayHasKey('.travis.yml', $files);
+        $this->assertNotEmpty($files['.travis.yml']);
+    }
+}


### PR DESCRIPTION
I have added an optional "Travis CI configuration" feature that will generate a `.travis.yml` file and place it in the root of the generated plugin. By default, that option is turned off. 

The template for `.travis.yml` is the current `.travis.dist.yml` at https://github.com/moodlehq/moodle-plugin-ci/ (i. e., https://github.com/moodlehq/moodle-plugin-ci/blob/d32fbdd2570c119ee84de233e31f6e0e61c018b5/.travis.dist.yml for future reference).

@mudrd8mz I am not sure whether you even want to have that feature. But I recently generated a plugin skeleton with your useful `tool_pluginskel` and forgot to add a `.travis.yml`to it, so I figured, let's add it to `tool_pluginskel` right away :)