### PR TITLE
Add a section to the README that contains the target installation directory

### DIFF
--- a/skel/file/readme.mustache
+++ b/skel/file/readme.mustache
@@ -1,8 +1,16 @@
 # {{ name }} #
 
+
 TODO Describe the plugin shortly here.
 
 TODO Provide more detailed description here.
+
+## Installation ##
+
+This plugin is installed by copying the files from this directory to
+`{{ component_root }}/{{ component_name }}`,
+relative to your Moodle installation root directory. Afterwards, open your
+Moodle site in a browser to complete the installation.
 
 ## License ##
 


### PR DESCRIPTION
I mean, for certain plugin types (and also, for very common ones) it is very obvious where it needs to be placed. At least to plugin developers. But for rather unusual plugin types, say `customfield` or `fileconverter`, this piece of information is quite useful to have as part of the generated README.

May or may not be motivated by the fact that, despite having developed such plugins already, I had to look up the target directories for these types... repeatedly. :see_no_evil: 