### PR TITLE
Fix travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
   include:
     - php: 7.4
       env: MOODLE_BRANCH=master
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE
     - php: 7.3
       env: MOODLE_BRANCH=MOODLE_39_STABLE
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ script:
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
   - moodle-plugin-ci phpdoc
-  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci phpunit || [ $MOODLE_BRANCH -ne "master" ]
   - moodle-plugin-ci behat

--- a/tests/atto_test.php
+++ b/tests/atto_test.php
@@ -69,7 +69,7 @@ class tool_pluginskel_atto_testcase extends advanced_testcase {
     /**
      * Sets the the $plugintype.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         list($type, $name) = \core_component::normalize_component(self::$recipe['component']);
         self::$plugintype = $type;
         self::$pluginname = $name;

--- a/tests/block_test.php
+++ b/tests/block_test.php
@@ -101,7 +101,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
     /**
      * Sets the the $modname.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         global $CFG;
 
         list($type, $blockname) = \core_component::normalize_component(self::$recipe['component']);

--- a/tests/capabilities_test.php
+++ b/tests/capabilities_test.php
@@ -68,7 +68,7 @@ class tool_pluginskel_capabilities_testcase extends advanced_testcase {
     /**
      * Sets the the $plugintype.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         list($type, $name) = \core_component::normalize_component(self::$recipe['component']);
         self::$plugintype = $type;
     }

--- a/tests/mod_test.php
+++ b/tests/mod_test.php
@@ -143,7 +143,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
     /**
      * Sets the $relpath and the $modname.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         global $CFG;
 
         list($type, $modname) = \core_component::normalize_component(self::$recipe['component']);

--- a/tests/qtype_test.php
+++ b/tests/qtype_test.php
@@ -63,7 +63,7 @@ class tool_pluginskel_qtype_testcase extends advanced_testcase {
     /**
      * Sets the $qtypename.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         global $CFG;
 
         list($type, $qtypename) = \core_component::normalize_component(self::$recipe['component']);


### PR DESCRIPTION
My contributions in #102 & #103 made apparent that the Travis configuration was not working anymore (Postgres version was too low for master).

I've been meaning to get around to that. And now I have, but there was a complication: Moodle has bumped the required PHPUnit version to 8.5 in the meantime :) So this error followed after changing the Postgres version:

```
Fatal error: Declaration of tool_pluginskel_atto_testcase::setUpBeforeClass() must be compatible with PHPUnit\Framework\TestCase::setUpBeforeClass(): void in /home/travis/build/moodle/admin/tool/pluginskel/tests/atto_test.php on line 72
```

This is now fixed, but also requires limiting PHPUnit tests to a Moodle version that uses PHPUnit 8.5+. Note that there are a few deprecation warnings as well, preparing for PHPUnit 9. They could be tackled in a later change.

Merging this PR will make #102 and #103 run :)