### PR TITLE
Minor typo fix

### DIFF
--- a/skel/file/block/block.mustache
+++ b/skel/file/block/block.mustache
@@ -78,7 +78,7 @@ class {{ component }} extends block_base {
     /**
      * Defines configuration data.
      *
-     * The function is called immediatly after init().
+     * The function is called immediately after init().
      */
     public function specialization() {
 


### PR DESCRIPTION
Thanks for the useful plugin.

Just fixed a minor typo when generating a block.