### PR TITLE
assertRegExp() and assertNotRegExp() are deprecated

### DIFF
--- a/tests/atto_test.php
+++ b/tests/atto_test.php
@@ -102,7 +102,7 @@ class tool_pluginskel_atto_testcase extends advanced_testcase {
         $paramname = $recipe['atto_features']['params_for_js'][0]['name'];
         $default = $recipe['atto_features']['params_for_js'][0]['default'];
         $attrs = '/ATTRS: {\s+'.$paramname.': {\s+value: \''.$default.'\'/';
-        $this->assertRegExp($attrs, $buttonjsfile);
+        $this->assertMatchesRegularExpression($attrs, $buttonjsfile);
     }
 
     /**
@@ -169,7 +169,7 @@ class tool_pluginskel_atto_testcase extends advanced_testcase {
 
         $id = $recipe['atto_features']['strings_for_js'][0]['id'];
         $strings = '/\$PAGE->requires_strings_for_js\(array\(\s+\''.$id.'\',\s+\)\)/';
-        $this->assertRegExp($strings, $libfile);
+        $this->assertMatchesRegularExpression($strings, $libfile);
 
         $paramsforjs = 'function '.$recipe['component'].'_params_for_js($elementid, $options, $foptions)';
         $this->assertStringContainsString($paramsforjs, $libfile);
@@ -177,7 +177,7 @@ class tool_pluginskel_atto_testcase extends advanced_testcase {
         $paramname = $recipe['atto_features']['params_for_js'][0]['name'];
         $value = $recipe['atto_features']['params_for_js'][0]['value'];
         $params = '/return array\(\s+\''.$paramname.'\' => \''.$value.'\',\s+\);/';
-        $this->assertRegExp($params, $libfile);
+        $this->assertMatchesRegularExpression($params, $libfile);
     }
 
     /**

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -106,7 +106,7 @@ class tool_pluginskel_auth_testcase extends advanced_testcase {
             $function = '/public function '.$functionname.'\(\) {';
             $returnvalue = $recipe['auth_features'][$functionname] == true ? 'true' : 'false';
             $function .= '\s+return '.$returnvalue.';/';
-            $this->assertRegExp($function, $authfile);
+            $this->assertMatchesRegularExpression($function, $authfile);
         }
 
         $canchangepassword = 'public function can_change_password()';

--- a/tests/block_test.php
+++ b/tests/block_test.php
@@ -140,7 +140,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $this->assertStringNotContainsString($moodleinternal, $blockfile);
 
         // The block file should not include the config.php file.
-        $this->assertNotRegExp('/require.+config\.php/', $blockfile);
+        $this->assertDoesNotMatchRegularExpression('/require.+config\.php/', $blockfile);
 
         $classdefinition = 'class '.$recipe['component'].' extends block_base';
         $this->assertStringContainsString($classdefinition, $blockfile);
@@ -199,7 +199,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $this->assertStringNotContainsString($moodleinternal, $editformfile);
 
         // The edit_form file should not include the config.php file.
-        $this->assertNotRegExp('/require.+config\.php/', $editformfile);
+        $this->assertDoesNotMatchRegularExpression('/require.+config\.php/', $editformfile);
 
         $classdefinition = 'class '.$recipe['component'].'_edit_form extends block_edit_form';
         $this->assertStringContainsString($classdefinition, $editformfile);
@@ -229,7 +229,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $description = 'The task that provides all the steps to perform a complete backup is defined here.';
         $this->assertStringContainsString($description, $taskfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $taskfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $taskfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $taskfile);
@@ -267,7 +267,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $description = 'Plugin custom settings are defined here.';
         $this->assertStringContainsString($description, $settingslibfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $settingslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $settingslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $settingslibfile);
@@ -296,7 +296,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $description = 'Backup steps for '.$recipe['component'].' are defined here.';
         $this->assertStringContainsString($description, $stepslibfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $stepslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $stepslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $stepslibfile);
@@ -332,7 +332,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $description = 'The task that provides a complete restore of '.$recipe['component'].' is defined here.';
         $this->assertStringContainsString($description, $restorefile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $restorefile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $restorefile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $restorefile);
@@ -367,7 +367,7 @@ class tool_pluginskel_block_testcase extends advanced_testcase {
         $description = 'All the steps to restore '.$recipe['component'].' are defined here.';
         $this->assertStringContainsString($description, $stepslibfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $stepslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $stepslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $stepslibfile);

--- a/tests/capabilities_test.php
+++ b/tests/capabilities_test.php
@@ -91,7 +91,7 @@ class tool_pluginskel_capabilities_testcase extends advanced_testcase {
 
         // Verify the boilerplate.
         $this->assertStringContainsString('Plugin capabilities are defined here.', $dbaccessfile);
-        $this->assertRegExp('/\* @category\s+access/', $dbaccessfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+access/', $dbaccessfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die()";
         $this->assertStringContainsString($moodleinternal, $dbaccessfile);

--- a/tests/enrol_test.php
+++ b/tests/enrol_test.php
@@ -136,18 +136,18 @@ class tool_pluginskel_enrol_testcase extends advanced_testcase {
 
         $returnvalue = $recipe['enrol_features']['allow_enrol'] == true ? 'true' : 'false';
         $allowenrol = '/public function allow_enrol\(\$instance\) {\s+return '.$returnvalue.';/';
-        $this->assertRegExp($allowenrol, $libfile);
+        $this->assertMatchesRegularExpression($allowenrol, $libfile);
 
         $returnvalue = $recipe['enrol_features']['allow_unenrol'] == true ? 'true' : 'false';
         $allowunenrol = '/public function allow_unenrol\(\$instance\) {\s+return '.$returnvalue.';/';
-        $this->assertRegExp($allowunenrol, $libfile);
+        $this->assertMatchesRegularExpression($allowunenrol, $libfile);
 
         $returnvalue = $recipe['enrol_features']['allow_manage'] == true ? 'true' : 'false';
         $allowmanage = '/public function allow_manage\(\$instance\) {\s+return '.$returnvalue.';/';
-        $this->assertRegExp($allowmanage, $libfile);
+        $this->assertMatchesRegularExpression($allowmanage, $libfile);
 
         $returnvalue = $recipe['enrol_features']['allow_unenrol_user'] == true ? 'true' : 'false';
         $allowunenroluser = '/public function allow_unenrol_user\(\$instance\, \$ue\) {\s+return '.$returnvalue.';/';
-        $this->assertRegExp($allowunenroluser, $libfile);
+        $this->assertMatchesRegularExpression($allowunenroluser, $libfile);
     }
 }

--- a/tests/lang_test.php
+++ b/tests/lang_test.php
@@ -71,7 +71,7 @@ class tool_pluginskel_lang_testcase extends advanced_testcase {
         $langfile = $files['lang/en/'.$recipe['component'].'.php'];
 
         $this->assertStringContainsString('Plugin strings are defined here.', $langfile);
-        $this->assertRegExp('/\* @category\s+string/', $langfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+string/', $langfile);
         $this->assertStringContainsString("\$string['pluginname'] = '".$recipe['name'], $langfile);
 
         $id = $recipe['lang_strings'][0]['id'];

--- a/tests/mod_test.php
+++ b/tests/mod_test.php
@@ -331,7 +331,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
 
         $libfile = $files['lib.php'];
 
-        $this->assertRegExp('/case FEATURE_GRADE_HAS_GRADE:\s+return true/', $libfile);
+        $this->assertMatchesRegularExpression('/case FEATURE_GRADE_HAS_GRADE:\s+return true/', $libfile);
 
         $scaleused = 'function demo_scale_used($moduleinstanceid, $scaleid)';
         $this->assertStringContainsString($scaleused, $libfile);
@@ -434,7 +434,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
         $description = 'The task that provides all the steps to perform a complete backup is defined here.';
         $this->assertStringContainsString($description, $taskfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $taskfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $taskfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $taskfile);
@@ -475,7 +475,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
         // Verify the boilerplate.
         $description = 'Plugin custom settings are defined here.';
         $this->assertStringContainsString($description, $settingslibfile);
-        $this->assertRegExp('/\* @category\s+backup/', $settingslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $settingslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $settingslibfile);
@@ -510,7 +510,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
         $description = 'Backup steps for mod_demo are defined here.';
         $this->assertStringContainsString($description, $stepslibfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $stepslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $stepslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $stepslibfile);
@@ -546,7 +546,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
         $description = 'The task that provides a complete restore of mod_demo is defined here.';
         $this->assertStringContainsString($description, $restorefile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $restorefile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $restorefile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $restorefile);
@@ -585,7 +585,7 @@ class tool_pluginskel_mod_testcase extends advanced_testcase {
         $description = 'All the steps to restore mod_demo are defined here.';
         $this->assertStringContainsString($description, $stepslibfile);
 
-        $this->assertRegExp('/\* @category\s+backup/', $stepslibfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+backup/', $stepslibfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die();";
         $this->assertStringContainsString($moodleinternal, $stepslibfile);

--- a/tests/observers_test.php
+++ b/tests/observers_test.php
@@ -114,7 +114,7 @@ class tool_pluginskel_observers_testcase extends advanced_testcase {
             }
 
             $observer .= '\),/';
-            $this->assertRegExp($observer, $eventsfile);
+            $this->assertMatchesRegularExpression($observer, $eventsfile);
         }
     }
 

--- a/tests/settings_test.php
+++ b/tests/settings_test.php
@@ -67,7 +67,7 @@ class tool_pluginskel_settings_testcase extends advanced_testcase {
         $this->assertArrayHasKey('settings.php', $files);
         $settingsfile = $files['settings.php'];
         $this->assertStringContainsString('Plugin administration pages are defined here.', $settingsfile);
-        $this->assertRegExp('/\* @category\s+admin/', $settingsfile);
+        $this->assertMatchesRegularExpression('/\* @category\s+admin/', $settingsfile);
 
         $moodleinternal = "defined('MOODLE_INTERNAL') || die()";
         $this->assertStringContainsString($moodleinternal, $settingsfile);

--- a/tests/theme_test.php
+++ b/tests/theme_test.php
@@ -89,11 +89,11 @@ class tool_pluginskel_theme_testcase extends advanced_testcase {
 
         $basetheme = $recipe['theme_features']['parents'][0]['base_theme'];
         $parents = '/\$THEME->parents = array\(\s+\''.$basetheme.'\',\s+\)/';
-        $this->assertRegExp($parents, $configfile);
+        $this->assertMatchesRegularExpression($parents, $configfile);
 
         $stylesheetname = $recipe['theme_features']['stylesheets'][0]['name'];
         $stylesheets = '/\$THEME->sheets = array\(\s*\''.$stylesheetname.'\',\s*\);/';
-        $this->assertRegExp($stylesheets, $configfile);
+        $this->assertMatchesRegularExpression($stylesheets, $configfile);
 
         $layouts = '$THEME->layouts = array(';
         $this->assertStringContainsString($layouts, $configfile);


### PR DESCRIPTION
assertRegExp() and assertNotRegExp() are deprecated and will be removed in PHPUnit 10.