### PR TITLE
tiny: avoid having the id string 'pluginname' twice

### DIFF
--- a/classes/local/util/manager.php
+++ b/classes/local/util/manager.php
@@ -949,7 +949,6 @@ class manager {
                 }
 
                 $menuitem['menuItemName'] = "{$menuitem['name']}MenuItemName";
-                $this->add_lang_string('pluginname', $menuitem['text']);
                 $this->add_lang_string("menuitem_{$menuitem['name']}", $menuitem['text']);
                 $menuitems[] = $menuitem;
 


### PR DESCRIPTION
When we use [the following example](https://moodledev.io/docs/apis/plugintypes/tiny#creating-a-new-plugin), the `lang/en/tiny_example.php` file have two strings with `pluginname` id: 
```php
$string['pluginname'] = 'Start the demo';
$string['pluginname'] = 'Example Plugin';
```
This PR should remove `$string['pluginname'] = 'Start the demo';` line.