### PR TITLE
tiny: replace component placeholder with component name in JSDoc

### DIFF
--- a/skel/file/tiny/commands_js.mustache
+++ b/skel/file/tiny/commands_js.mustache
@@ -30,9 +30,10 @@
     }
 }}
 {{< common/boilerplate_amd_js }}
-{{$ description }}Commands helper for the Moodle {{ component }} plugin.{{/ description }}
-{{$ modulename }}commands{{/ modulename }}
-{{$ copyright }}{{ copyright }}{{/ copyright }}
+    {{$ description }}Commands helper for the Moodle {{ component }} plugin.{{/ description }}
+    {{$ modulename }}commands{{/ modulename }}
+    {{$ package }}{{ component }}{{/ package }}
+    {{$ copyright }}{{ copyright }}{{/ copyright }}
 {{/ common/boilerplate_amd_js }}
 
 {{# self.defines_buttons }}

--- a/skel/file/tiny/common_js.mustache
+++ b/skel/file/tiny/common_js.mustache
@@ -32,8 +32,9 @@
 {{< common/boilerplate_amd_js }}
     {{$ description }}Common values helper for the Moodle {{ component }} plugin.{{/ description }}
     {{$ modulename }}common{{/ modulename }}
+    {{$ package }}{{ component }}{{/ package }}
     {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{/ common/boilerplate_amd_js  }}
+{{/ common/boilerplate_amd_js }}
 
 const component = '{{component}}';
 

--- a/skel/file/tiny/configuration_js.mustache
+++ b/skel/file/tiny/configuration_js.mustache
@@ -32,8 +32,9 @@
 {{< common/boilerplate_amd_js }}
     {{$ description }}Tiny {{ component }} for Moodle.{{/ description }}
     {{$ modulename }}plugin{{/ modulename }}
+    {{$ package }}{{ component }}{{/ package }}
     {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{/ common/boilerplate_amd_js  }}
+{{/ common/boilerplate_amd_js }}
 
 import {
 {{# self.commandnames }}

--- a/skel/file/tiny/options_js.mustache
+++ b/skel/file/tiny/options_js.mustache
@@ -32,8 +32,9 @@
 {{< common/boilerplate_amd_js }}
     {{$ description }}Options helper for the Moodle {{ component }} plugin.{{/ description }}
     {{$ modulename }}options{{/ modulename }}
+    {{$ package }}{{ component }}{{/ package }}
     {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{/ common/boilerplate_amd_js  }}
+{{/ common/boilerplate_amd_js }}
 
 import {getPluginOptionName} from 'editor_tiny/options';
 import {pluginName} from './common';

--- a/skel/file/tiny/plugin_js.mustache
+++ b/skel/file/tiny/plugin_js.mustache
@@ -32,8 +32,9 @@
 {{< common/boilerplate_amd_js }}
     {{$ description }}Tiny {{ component }} for Moodle.{{/ description }}
     {{$ modulename }}plugin{{/ modulename }}
+    {{$ package }}{{ component }}{{/ package }}
     {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{/ common/boilerplate_amd_js  }}
+{{/ common/boilerplate_amd_js }}
 
 import {getTinyMCE} from 'editor_tiny/loader';
 import {getPluginMetadata} from 'editor_tiny/utils';


### PR DESCRIPTION
When we use [the following example](https://moodledev.io/docs/apis/plugintypes/tiny#creating-a-new-plugin), the generated files in `amd/src/` directory use a placeholder for `@module` tag:

```js
/**
 * Commands helper for the Moodle tiny_example plugin.
 *
 * @module      plugintype_pluginname/commands
 * @copyright   2022 Andrew Lyons <andrew@nicols.co.uk>
 * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 */
```
This PR should replace `plugintype_pluginname` by the real component name (here `tiny_example`).