### PR TITLE
atto button_js: use js boilerplate, use documented variables

### DIFF
--- a/skel/file/atto/button_js.mustache
+++ b/skel/file/atto/button_js.mustache
@@ -29,14 +29,14 @@
         "copyright": "2021 David Mudrák <david@moodle.com>"
     }
 }}
-{{< common/boilerplate_php }}
-{{$ description }}The Atto plugin {{ component_name }} is defined here.{{/ description }}
-{{$ package }}{{ component }}{{/ package }}
+{{< common/boilerplate_amd_js }}
+{{$ description }}The Atto plugin {{ component }} is defined here.{{/ description }}
+{{$ modulename }}button{{/ modulename }}
 {{$ copyright }}{{ copyright }}{{/ copyright }}
-{{/ common/boilerplate_php }}
+{{/ common/boilerplate_amd_js }}
 
 /**
- * Atto {{ component_name }} plugin.
+ * Atto {{ component }} plugin.
  *
  * @namespace M.{{ component }}.
  * @class button.


### PR DESCRIPTION
Fixes #124 

The documented context variables do not include `component_name`, so I switched them to `component`. If `component_name` does exists, then it should be added to the list of documented context variables.